### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ## Ganache
 
+[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/trufflesuite/ganache-ui/badge)](https://www.gitpoap.io/gh/trufflesuite/ganache-ui)
+
 Ganache is your personal blockchain for Ethereum development. 
 
 <p align="center">


### PR DESCRIPTION
## Ganache

Thank you for contributing! Take a moment to review our [**contributing guidelines**](https://github.com/trufflesuite/ganache/blob/master/.github/CONTRIBUTING.md) to make the process easy and effective for everyone involved.

**You must open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/trufflesuite/ganache/blob/master/.github/CONTRIBUTING.md)
- [ ] Pull request has tests (**Note**: Not applicable since this only updates the README
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch via a Pull Request, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/trufflesuite/ganache/blob/master/LICENSE.md).

## Description

Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie
