### PR TITLE
fix: corrects the "value transfer" label, and "to address" in transaction list

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,26 +2,27 @@ module.exports = {
   extends: ["prettier", "eslint:recommended", "plugin:react/recommended"],
   plugins: ["prettier", "react", "jest", "react-hooks"],
   rules: {
+    "no-prototype-builtins": "warn",
     "no-console": "warn",
     "react/prop-types": 0,
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn",
   },
   parserOptions: {
-    "ecmaVersion": 2020,
-    "sourceType": "module"
+    ecmaVersion: 2020,
+    sourceType: "module",
   },
   env: {
     es6: true,
     browser: true,
     node: true,
     mocha: true,
-    "jest/globals": true
+    "jest/globals": true,
   },
   settings: {
     react: {
-      version: "detect"
-    }
+      version: "detect",
+    },
   },
-  parser: "babel-eslint"
+  parser: "babel-eslint",
 };

--- a/src/integrations/ethereum/renderer/screens/transactions/DestinationAddress.js
+++ b/src/integrations/ethereum/renderer/screens/transactions/DestinationAddress.js
@@ -5,7 +5,7 @@ export default class DestinationAddress extends Component {
     const isContractCall =
       (this.props.receipt.hasOwnProperty("contractAddress") &&
         this.props.receipt.contractAddress !== null) ||
-      (this.props.tx.to && this.props.tx.input);
+      (this.props.tx.to && this.props.tx.input !== "0x");
 
     const isContractCreationCall =
       this.props.receipt.hasOwnProperty("contractAddress") &&

--- a/src/integrations/ethereum/renderer/screens/transactions/TransactionTypeBadge.js
+++ b/src/integrations/ethereum/renderer/screens/transactions/TransactionTypeBadge.js
@@ -13,7 +13,7 @@ export default class TransactionTypeBadge extends Component {
       );
     }
 
-    if (this.props.tx.to && this.props.tx.input) {
+    if (this.props.tx.to && this.props.tx.input !== "0x") {
       return (
         <div className="TransactionTypeBadge ContractCallBadge">
           CONTRACT CALL


### PR DESCRIPTION
Previously a "value transfer" transaction was shown as a "contract call", and the "to address" was shown as "contract address".

With this change, the correct label "value transfer" is shown, along with "to address".

