### PR TITLE
Don't start the chain server when loading the configuration screen

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -583,10 +583,6 @@ app.on("ready", async () => {
       workspace.contractCache.getAll()
     );
 
-    if (!(await integrations.startServer())) {
-      return;
-    }
-
     if (workspace) {
       const globalSettings = global.getAll();
       const workspaceSettings = workspace.settings.getAll();


### PR DESCRIPTION
When loading the workspace configuration screen, we immediately start the chain. This does actually makes sense, as the chain is a wrapper around Ganache which forks the nodejs process.

Previously we also immediately called `startServer()` which actually starts the Ganache instance. Now we only call `startServer()` when actually starting the Workspace.