### PR TITLE
Add warning icon to workspace page for legacy workspaces

### DIFF
--- a/src/renderer/screens/appshell/TopNavbar.js
+++ b/src/renderer/screens/appshell/TopNavbar.js
@@ -19,6 +19,7 @@ import OnlyIf from "../../components/only-if/OnlyIf";
 import StatusIndicator from "../../components/status-indicator/StatusIndicator";
 import UpdateNotification from "../auto-update/UpdateNotification";
 
+import WarningIcon from "../../icons/warning.svg";
 import AccountIcon from "../../icons/account.svg";
 import BlockIcon from "../../icons/blocks.svg";
 import TxIcon from "../../icons/transactions.svg";
@@ -231,7 +232,18 @@ class TopNavbar extends Component {
             <StatusIndicator
               title="WORKSPACE"
               value={this.props.config.settings.workspace.name}
-            />
+            >
+              <OnlyIf test={this.props.config.settings.workspace.libVersion === 2}>
+                <span className="popover-container">
+                  <span className="popover popunder">
+                    This workspace was created with an old version of Ganache.
+                    <br />
+                    Create a new workspace to take advantage of Ganache v7.
+                  </span>
+                  <WarningIcon width="25px" height="25px" />
+                </span>
+              </OnlyIf>
+            </StatusIndicator>
             <OnlyIf test={this.props.config.settings.workspace.isDefault}>
               <button onClick={this.handleSaveWorkspacePress.bind(this)}>Save</button>
             </OnlyIf>


### PR DESCRIPTION
Accidentally removed in https://github.com/trufflesuite/ganache-ui/pull/5070