### PR TITLE
Correctly resolve the response from `serverStart()`

### DIFF
--- a/src/integrations/ethereum/common/services/EthereumChainService.js
+++ b/src/integrations/ethereum/common/services/EthereumChainService.js
@@ -78,10 +78,10 @@ export default class EthereumChainService extends EventEmitter {
           resolve();
         };
         const handleServerError = (e) => {
-          this.removeListener("server-started", handleServerStarted);
+          this.removeListener("server-started-data", handleServerStarted);
           reject(e);
         };
-        this.once("server-started", handleServerStarted);
+        this.once("server-started-data", handleServerStarted);
         this.once("error", handleServerError);
         this._child.send({
           type: "start-server",

--- a/src/integrations/filecoin/common/services/FilecoinChainService.js
+++ b/src/integrations/filecoin/common/services/FilecoinChainService.js
@@ -73,10 +73,10 @@ class FilecoinChainService extends EventEmitter {
           resolve();
         };
         const handleServerError = (e) => {
-          this.removeListener("server-started", handleServerStarted);
+          this.removeListener("server-started-data", handleServerStarted);
           reject(e);
         };
-        this.once("server-started", handleServerStarted);
+        this.once("server-started-data", handleServerStarted);
         this.once("error", handleServerError);
         this._child.send({
           type: "start-server",


### PR DESCRIPTION
Fixes a couple of different issues, including populating the network interfaces dropdown, and the `forked networks` header