### PR TITLE
fix: move workspaces to `Ganache/ui/workspaces`

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -97,7 +97,7 @@ if (process.platform === "win32") {
       return spawn("cmd.exe", ["/c", "mkdir", path.join(USERDATA_PATH, "extras")])
     })
     .then(()=> {
-      return spawn("cmd.exe", ["/c", "mkdir", path.join(USERDATA_PATH, "workspaces")])
+      return spawn("cmd.exe", ["/c", "mkdir", path.join(USERDATA_PATH, "ui/workspaces")])
     })
     .then(()=> {
       return spawn("cmd.exe", ["/c", "mkdir", path.join(USERDATA_PATH, "default")])
@@ -120,7 +120,7 @@ if (process.platform === "win32") {
     }
   });
 } else {
-  migrationPromise = Promise.resolve();
+  migrationPromise = migration.migrate(USERDATA_PATH);
 
   // https://github.com/sindresorhus/fix-path
   // GUI apps on macOS don't inherit the $PATH defined in your dotfiles (.bashrc/.bash_profile/.zshrc/etc)

--- a/src/main/init/migration.js
+++ b/src/main/init/migration.js
@@ -31,8 +31,8 @@ const linkLegacyWorkspaces = async (configRoot) => {
     const linkingWorkspaces = legacyWorkspaces.map(async legacyWorkspace => {
       const fullPath = join(legacyWorkspacesDirectory, legacyWorkspace.name);
       const linkPath = join(newWorkspacesDirectory, legacyWorkspace.name);
-      if (legacyWorkspace.isDirectory && !await exists(linkPath)) {
-        return symlink(fullPath, linkPath);
+      if (legacyWorkspace.isDirectory() && !await exists(linkPath)) {
+        return symlink(fullPath, linkPath, "junction");
       }
     });
 
@@ -93,13 +93,13 @@ if (process.platform == "win32") {
    * workspace folder.
    */
   migrate = async (newGanache) => {
-    if (!APP_DATA) return;
-    const oldGanache = getOldGanachePath();
-    
-    if (!(await ganacheExists())) return;
+    if (APP_DATA && await ganacheExists()) {      
+      const oldGanache = getOldGanachePath();
+      
+      const newGanacheVirtualized = join(APP_DATA, `/../Local/Packages/${pkg.build.appx.identityName}_5dg5pnz03psnj/LocalCache/Roaming/Ganache`);
+      await Promise.all([moveWorkspaces(oldGanache, newGanache), moveGlobalSettings(oldGanache, newGanache), moveWorkspaces(newGanacheVirtualized, newGanache), moveGlobalSettings(newGanacheVirtualized, newGanache)]);
+    }
 
-    const newGanacheVirtualized = join(APP_DATA, `/../Local/Packages/${pkg.build.appx.identityName}_5dg5pnz03psnj/LocalCache/Roaming/Ganache`);
-    await Promise.all([moveWorkspaces(oldGanache, newGanache), moveGlobalSettings(oldGanache, newGanache), moveWorkspaces(newGanacheVirtualized, newGanache), moveGlobalSettings(newGanacheVirtualized, newGanache)]);
     return linkLegacyWorkspaces(newGanache);
   };
 

--- a/src/main/init/migration.js
+++ b/src/main/init/migration.js
@@ -13,7 +13,8 @@ let migrate, uninstallOld;
   directory. This means that the old workspaces are available to both new and
   old versions of Ganache-UI, but new workspaces are only available to new 
   versions.
-  The intention is ot migrate all Ganache-UI data to the /Ganache/ui directory,
+  The intention is to migrate all Ganache-UI data to the /Ganache/ui directory,
+
   giving the user the option to move (and migrate the chaindata of) legacy
   workspaces.
   See: https://github.com/trufflesuite/ganache-ui/pull/5151

--- a/src/main/types/workspaces/Workspace.js
+++ b/src/main/types/workspaces/Workspace.js
@@ -120,8 +120,16 @@ class Workspace {
   }
 
   delete() {
+    let workspaceDirectory;
+    if (fse.lstatSync(this.workspaceDirectory).isSymbolicLink()) {
+      workspaceDirectory = fse.readlinkSync(this.workspaceDirectory);
+      fse.unlinkSync(this.workspaceDirectory);
+    } else {
+      workspaceDirectory = this.workspaceDirectory;
+    }
+
     try {
-      fse.removeSync(this.workspaceDirectory);
+      fse.removeSync(workspaceDirectory);
     } catch (e) {
       // TODO: couldn't delete the directory; probably don't have
       // permissions or some file is open somewhere. we probably
@@ -129,6 +137,9 @@ class Workspace {
       // a message to renderer process, display toast saying there
       // were issues, etc.). Don't really have time right now for
       // a solution here
+      // todo: if unlinking is successful, but removing the
+      // directory is not, the link will be recreated during the
+      // migration process next time the app is started.
     }
   }
 

--- a/src/main/types/workspaces/Workspace.js
+++ b/src/main/types/workspaces/Workspace.js
@@ -1,6 +1,5 @@
 import path from "path";
 import fse from "fs-extra";
-
 import WorkspaceSettings from "../settings/WorkspaceSettings";
 import ContractCache from "../../../integrations/ethereum/main/types/contracts/ContractCache";
 
@@ -54,7 +53,7 @@ class Workspace {
         return path.join(configDirectory, `default_${flavor}`);
       }
     } else {
-      return path.join(configDirectory, "workspaces", sanitizedName);
+      return path.join(configDirectory, "ui/workspaces", sanitizedName);
     }
   }
 


### PR DESCRIPTION
This changes the workspaces directory to `<config>/Ganache/ui/workspaces` in anticipation of all Ganache-UI configuration data being migrated to the `<config>Ganache/ui` directory. This means that previous versions of Ganache-UI will not have visibility to "new" workspaces. 

During the "migration" phase of startup, all workspaces in the "old" location will have symlinks created in the "new" location - meaning that "old" workspaces are available in the "new" version of Ganache-UI.

Deleting workspaces in either version of Ganache-UI will cause the workspace to be deleted for both.