### PR TITLE
Only use the last selected flavor if it is supported

### DIFF
--- a/src/renderer/screens/startup/HomeScreen.js
+++ b/src/renderer/screens/startup/HomeScreen.js
@@ -29,7 +29,13 @@ import ReactTooltip from "react-tooltip";
 class HomeScreen extends Component {
   constructor(props) {
     super(props);
-    this.state = {flavor: this.props.config.settings.global.last_flavor || "ethereum"};
+    const lastFlavor = this.props.config.settings.global.last_flavor;
+    const flavor =
+      lastFlavor === "ethereum" || lastFlavor === "filecoin"
+        ? lastFlavor
+        : "ethereum";
+
+    this.state = { flavor };
 
     this.handleFlavorChange = this.handleFlavorChange.bind(this);
     this.handleClickOutside = this.handleClickOutside.bind(this);
@@ -38,6 +44,7 @@ class HomeScreen extends Component {
   selectWorkspace(workspace) {
     this.props.dispatch(openWorkspace(workspace.name, workspace.flavor));
   }
+
   handleEditWorkspaceSettings(workspace, e) {
     const workspaceName = workspace.name;
     const workspaceFlavor = workspace.flavor;


### PR DESCRIPTION
When loading the home screen, the previously selected flavor is always selected by default - for instance, if the user last started a "Filecoin" workspace, then the "Filecoin" flavor would be selected.

Before to this change, if the previously selected flavor was no longer supported (ie "Corda"), it would still be selected. Starting the workspace would cause an error "Workspace not found" to be thrown.

This change causes the default ("Ethereum") workspace to be selected if the previously selected flavor is no longer supported. 