### PR TITLE
fix: Fork block number doesn't get populated

### DIFF
--- a/src/integrations/ethereum/renderer/screens/config/ConfigScreens/ServerScreen.js
+++ b/src/integrations/ethereum/renderer/screens/config/ConfigScreens/ServerScreen.js
@@ -454,7 +454,7 @@ class ServerScreen extends Component {
                   />
                 </div> 
                 <div className="RowItem">
-                  <p>The URL of the block number to fork from, e.g., 56789</p>
+                  <p>The block number to fork from, e.g., 56789</p>
                 </div>
               </div> 
             </section>

--- a/src/integrations/index.js
+++ b/src/integrations/index.js
@@ -97,8 +97,7 @@ class IntegrationManager extends EventEmitter {
       try {
         await this.flavor.startServer(settings, this.workspace.workspaceDirectory);
         // just incase startServer mutates the settings, save them
-        // todo: not sure whether we still need to do this?
-        this.workspace.settings.setAll(settings);
+        this.workspace.settings.setAll(this.workspace.settings.getAll());
 
         this.emit("server-started");
         return true;

--- a/static/node/chain/chain.ethereum.js
+++ b/static/node/chain/chain.ethereum.js
@@ -152,6 +152,7 @@ async function startServer(options) {
   dbLocation = ganacheOptions.database.dbPath;
 
   const { mnemonic, hdPath } = ganacheOptions.wallet;
+  const fork_block_number = ganacheOptions.fork?.blockNumber;
 
   // todo: what else do we need from options
   const data = {
@@ -159,6 +160,7 @@ async function startServer(options) {
     addresses,
     hdPath,
     mnemonic,
+    fork_block_number,
     dbLocation,
   };
 


### PR DESCRIPTION
If no fork block is supplied when configuring the chain, the fork block number should be propagated back from chain service, persisted to `Settings` and presented in the UI.

Previously this was not happening, and the workspace would fork latest every time it were started.