### PR TITLE
Only load blocks, events and transactions from after the fork block

### DIFF
--- a/src/integrations/ethereum/common/redux/blocks/actions.js
+++ b/src/integrations/ethereum/common/redux/blocks/actions.js
@@ -13,10 +13,15 @@ export const clearBlocksInView = function() {
 };
 
 export const requestPage = function(startBlockNumber, endBlockNumber) {
-  endBlockNumber = endBlockNumber || 0;
   return function(dispatch, getState) {
     if (startBlockNumber == null) {
       startBlockNumber = getState().core.latestBlock;
+    }
+    if (endBlockNumber == null) {
+      const state = getState();
+      endBlockNumber = state.config.settings.workspace.server.fork
+        ? state.config.settings.workspace.server.fork_block_number + 1
+        : 0;
     }
 
     let earliestBlockToRequest = Math.max(

--- a/src/integrations/ethereum/common/redux/events/actions.js
+++ b/src/integrations/ethereum/common/redux/events/actions.js
@@ -19,11 +19,17 @@ export const setSubscribedTopics = function(topics) {
 
 export const SET_LOADING = `${prefix}/SET_LOADING`;
 export const requestPage = function(startBlockNumber, endBlockNumber) {
-  endBlockNumber = endBlockNumber || 0;
   return async function(dispatch, getState) {
     if (startBlockNumber == null) {
       startBlockNumber = getState().core.latestBlock;
     }
+    if (endBlockNumber == null) {
+      const state = getState();
+      endBlockNumber = state.config.settings.workspace.server.fork
+        ? state.config.settings.workspace.server.fork_block_number + 1
+        : 0;
+    }
+
 
     let earliestBlockToRequest = Math.max(
       startBlockNumber - PAGE_SIZE,

--- a/src/integrations/ethereum/common/redux/transactions/actions.js
+++ b/src/integrations/ethereum/common/redux/transactions/actions.js
@@ -17,10 +17,15 @@ export const clearTransactionsInView = function() {
 
 export const SET_LOADING = `${prefix}/SET_LOADING`;
 export const requestPage = function(startBlockNumber, endBlockNumber) {
-  endBlockNumber = endBlockNumber || 0;
   return function(dispatch, getState) {
     if (startBlockNumber == null) {
       startBlockNumber = getState().core.latestBlock;
+    }
+    if (endBlockNumber == null) {
+      const state = getState();
+      endBlockNumber = state.config.settings.workspace.server.fork
+        ? state.config.settings.workspace.server.fork_block_number + 1
+        : 0;
     }
 
     let earliestBlockRequested = Math.max(


### PR DESCRIPTION
Previously Ganache-UI would attempt to load blocks and transactions from before the fork block. This had the impact that in some scenarios, none of these views would load.

With this fix, only blocks (and related data) from after the fork block is loaded.