### PR TITLE
fix: all user configuration data now lives in `Ganache/ui`

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -80,7 +80,7 @@ if (isDevelopment) {
   app.commandLine.appendSwitch("remote-debugging-port", "9222");
 }
 
-const USERDATA_PATH = app.getPath("userData");
+const USERDATA_PATH = path.join(app.getPath("userData"), "/ui");
 let migrationPromise;
 
 if (process.platform === "win32") {
@@ -97,7 +97,7 @@ if (process.platform === "win32") {
       return spawn("cmd.exe", ["/c", "mkdir", path.join(USERDATA_PATH, "extras")])
     })
     .then(()=> {
-      return spawn("cmd.exe", ["/c", "mkdir", path.join(USERDATA_PATH, "ui/workspaces")])
+      return spawn("cmd.exe", ["/c", "mkdir", path.join(USERDATA_PATH, "workspaces")])
     })
     .then(()=> {
       return spawn("cmd.exe", ["/c", "mkdir", path.join(USERDATA_PATH, "default")])

--- a/src/main/init/migration.js
+++ b/src/main/init/migration.js
@@ -13,15 +13,12 @@ let migrate, uninstallOld;
   directory. This means that the old workspaces are available to both new and
   old versions of Ganache-UI, but new workspaces are only available to new 
   versions.
-  The intention is to migrate all Ganache-UI data to the /Ganache/ui directory,
 
-  giving the user the option to move (and migrate the chaindata of) legacy
-  workspaces.
   See: https://github.com/trufflesuite/ganache-ui/pull/5151
 */
 const linkLegacyWorkspaces = async (configRoot) => {
-  const legacyWorkspacesDirectory = join(configRoot, "workspaces");
-  const newWorkspacesDirectory = join(configRoot, "ui/workspaces");
+  const legacyWorkspacesDirectory = join(configRoot, "../workspaces");
+  const newWorkspacesDirectory = join(configRoot, "workspaces");
 
   if (!await exists(newWorkspacesDirectory)) {
     await mkdir(newWorkspacesDirectory, { recursive: true })

--- a/src/main/types/workspaces/Workspace.js
+++ b/src/main/types/workspaces/Workspace.js
@@ -53,7 +53,7 @@ class Workspace {
         return path.join(configDirectory, `default_${flavor}`);
       }
     } else {
-      return path.join(configDirectory, "ui/workspaces", sanitizedName);
+      return path.join(configDirectory, "workspaces", sanitizedName);
     }
   }
 

--- a/src/main/types/workspaces/WorkspaceManager.js
+++ b/src/main/types/workspaces/WorkspaceManager.js
@@ -11,7 +11,7 @@ class WorkspaceManager {
   }
 
   enumerateWorkspaces() {  
-    const workspacesDirectory = path.join(this.directory, "ui/workspaces");
+    const workspacesDirectory = path.join(this.directory, "workspaces");
 
     if (fse.existsSync(workspacesDirectory)) {
       this.workspaces = readdirSync(workspacesDirectory, { withFileTypes: true }).flatMap((file) => {


### PR DESCRIPTION
Previously to this change, running a `Quickstart` Ethereum workspace would cause the same workspace to no longer work in previous versions of Ganache due to the `hardfork` parameter becoming invalid.