### PR TITLE
fix: correctly handle errors from event decoder

### DIFF
--- a/src/integrations/ethereum/common/services/TruffleIntegrationService.js
+++ b/src/integrations/ethereum/common/services/TruffleIntegrationService.js
@@ -165,10 +165,12 @@ class TruffleIntegrationService extends EventEmitter {
     return new Promise((resolve, reject) => {
       if (this.child !== null && this.child.connected) {
         this.once("decode-event-response", data => {
-          if (typeof data === "object") {
-            resolve(data);
+          if (data && data.error) {
+            reject(data.error);
           } else {
-            reject(data);
+            // data may be `undefined`, in which case the raw event will be displayed
+            // see https://github.com/trufflesuite/ganache-ui/issues/5296 for details
+            resolve(data);
           }
         });
         this.child.send({


### PR DESCRIPTION
In some cases, when decoding an event, Ganache UI will throw an error, with the message `Cannot read property 'stack' of undefined`.

Specifically, if three conditions are met:
- There must be a subscription to the event identifier. This happens if there has been a contract artifact loaded which defines an event with a matching signature, but as per condition 3, that contract must not exist in the artifacts.
- There must be a contract artifact loaded, which is deployed to the address that raises the event
- The contract artifacts must not declare an event with a matching signature.

Further details can be seen here: https://github.com/jeffsmale90/ganache-ui-stack-repro

This change fixes the issue, by correctly handling errors from the decoder. This means that if the above conditions are met, the `decodedEvent` promise resolves to `undefined`, which causes the caller to render the raw data as "Encoded Event".

See #5341 for a similar fix for decoding transactions.

Fixes: #5337
Fixes: #5324
Fixes: #5296
Fixes: #5273
Fixes: #5224
Fixes: #5188
Fixes: #5159
Fixes: #5105
Fixes: #4926
Fixes: #4913
Fixes: #2728
Fixes: #2245
Fixes: #2552
Fixes: #1998
Fixes: #4984
Fixes: #4826
Fixes: #4952
Fixes: #4648
Fixes: #4537
Fixes: #4891
Fixes: #4410
Fixes: #4849
Fixes: #3762
Fixes: #3632
Fixes: #3600
Fixes: #3487
Fixes: #3440
Fixes: #3454
Fixes: #3218
Fixes: #3064
Fixes: #3047
Fixes: #2230
Fixes: #2851
Fixes: #2847
Fixes: #2718
Fixes: #2657
Fixes: #2592
Fixes: #2308
Fixes: #2145
Fixes: #1916
Fixes: #1748
Fixes: #4757
Fixes: #4758
Fixes: #4724
Fixes: #4551
Fixes: #4536
Fixes: #4513
Fixes: #4445
Fixes: #4311
Fixes: #4309
Fixes: #4129
Fixes: #4084
Fixes: #4036
Fixes: #3984
Fixes: #3819
Fixes: #3796
Fixes: #3039
Fixes: #2987
Fixes: #4521
Fixes: #3259
Fixes: #1339
Fixes: #1313